### PR TITLE
Set httpd.go to expected initial state

### DIFF
--- a/Ch02/02_04/httpd.go
+++ b/Ch02/02_04/httpd.go
@@ -7,14 +7,10 @@ import (
 	"net/http"
 )
 
-const (
-	maxSize = 100 * 1024 // 100KB
-)
-
 func logHandler(w http.ResponseWriter, r *http.Request) {
 	defer r.Body.Close()
 
-	data, err := io.ReadAll(io.LimitReader(r.Body, maxSize))
+	data, err := io.ReadAll(r.Body)
 	if err != nil {
 		http.Error(w, "can't read", http.StatusBadRequest)
 		return


### PR DESCRIPTION
Before this change, httpd.go and fix/httpd.go have the same content, so users following along won't see any difference between the before and after `cp fix/* .` like you do in the video.